### PR TITLE
Fixing 'Getting started' tile to 'Get started'

### DIFF
--- a/ui-bundle-docs/partials/nav-box-item.hbs
+++ b/ui-bundle-docs/partials/nav-box-item.hbs
@@ -10,7 +10,7 @@
               <div class="box-title">
                 <div class="get-started-image"></div>
                 <div class="title-info">
-                  Getting Started
+                  Get Started
                 </div>
               </div>
               <div class="box-description">Everything you need to start using Kobiton.</div>


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
Change "Getting started" to "Get started" on the landing page tiles.

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- Fixes #105 

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#file-nameing) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#navigation-bar).
    - I removed all localizations (like `en-us`) from my URLs.
