### PR TITLE
Adding generic 404

### DIFF
--- a/antora-playbook-docs.yml
+++ b/antora-playbook-docs.yml
@@ -1,5 +1,6 @@
 site:
   title: Kobiton Docs
+  url: https://docs.kobiton.com/
   keys:
     google_analytics: 'G-3EDKJJNC3S'
 


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
Adding a generic 404 page. One was already in our project but we needed to set the `url` key in the `antora-playbook-docs.yml` file. [Antora docs here](https://docs.antora.org/antora/latest/add-404-error-page/).

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- #108 

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
