### PR TITLE
Updating yarn scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,11 +69,22 @@ node --version
 yarn --version
 ```
 
-If Node.js and Yarn are installed, install project dependencies and build the docs locally by running:
+If Node.js and Yarn are installed, install project dependencies by running:
 
 ```plaintext
 yarn install
+```
+
+To build the docs [with logs](#antora-logs), run:
+
+```plaintext
 yarn local
+```
+
+To view the logs in your web browser, run:
+
+```plaintext
+yarn server
 ```
 
 ## Antora logs

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "./scripts/minify-css.sh && antora antora-playbook-docs.yml && antora antora-playbook-widget.yml",
     "local": "yarn run build && ./scripts/beautify-logs.py",
-    "server": "http-server build/docs -c-1 &",
+    "server": "http-server build/docs -c-1",
     "start-docs": "open ./build/docs",
     "start-widget": "open ./build/widget"
   },


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
Due to the changes in #137 , the typical method of viewing styled content locally no longer works (because of the remove of `.html` from strings). Antora suggests using this method to create a local server to view styled content instead:

```
http-server build/docs -c-1
```

So I've added a second script to our yarn scripts that will run that command:

```
yarn server
```

As of now, you'll probably want to have two separate terminal tabs: one to use `yarn local` and one to use `yarn server` -- this isn't the most elegant solution, but works as a minimum viable product. There should be an update to this workflow sometime in the future.

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- N/A

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
