### PR TITLE
Fix issue that when run build locally, it throws error about "sed".

### DIFF
--- a/scripts/minify-css.sh
+++ b/scripts/minify-css.sh
@@ -7,21 +7,20 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 TEMP_FILE_DOCS="$PROJECT_ROOT/ui-bundle-docs/css/temp.css"
 TEMP_FILE_WIDGET="$PROJECT_ROOT/ui-bundle-widget/css/temp.css"
 
-OS_ARCH=$(uname)
-
-echo "Image architecture: $OS_ARCH"
-
 # Merge all css files to 1 file excluding site.css.
 find $PROJECT_ROOT/ui-bundle-docs/css/ -type f -not -name 'site.css' -name '*.css' -exec cat {} \; | npx postcss --use postcss-import postcss-clean --no-map > "$TEMP_FILE_DOCS"
 find $PROJECT_ROOT/ui-bundle-widget/css/ -type f -not -name 'site.css' -name '*.css' -exec cat {} \; | npx postcss --use postcss-import postcss-clean --no-map > "$TEMP_FILE_WIDGET"
 
 # Remove all comments from the merged files (anything between /* and */).
-if [[ "$OS_ARCH" == "Linux" ]]; then
-  sed -i '' 's/\/\*.*\*\///g' "$TEMP_FILE_DOCS"
-  sed -i '' 's/\/\*.*\*\///g' "$TEMP_FILE_WIDGET"
-else
+if [[ "$KOBITON_ENVIRONMENT" == "standalone" ]]; then
+  # Somehow the sed command with '' doesn't work on images in the standalone environment.
   sed -i 's/\/\*.*\*\///g' "$TEMP_FILE_DOCS"
   sed -i 's/\/\*.*\*\///g' "$TEMP_FILE_WIDGET"
+else
+  # Local build & S3 build (production) needs a ''.
+  # Note that, the S3 and standalone arch is "Linux", local arch is "Darwin" (MacOS).
+  sed -i '' 's/\/\*.*\*\///g' "$TEMP_FILE_DOCS"
+  sed -i '' 's/\/\*.*\*\///g' "$TEMP_FILE_WIDGET"
 fi
 
 # Append the header comment.


### PR DESCRIPTION
### Summary
Currently, if you build docs on your local Mac, there will be some error about the "sed" command in the console.
It is not a critical error as it only happens when running the build locally, and the "minify-css.sh" function is just for optimizing CSS so it should not impact the normal render for the pages.

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- N/A

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [ ] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [ ] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
