### PR TITLE
Top level name changed from Debugging to virtualUSD. 

### DIFF
--- a/docs/modules/debugging/nav.adoc
+++ b/docs/modules/debugging/nav.adoc
@@ -1,4 +1,4 @@
-.xref:index.adoc[]
+.xref:index.adoc[virtualUSB]
 * xref:debugging:set-up-virtualusb.adoc[]
 * xref:debugging:add-virtualusb-to-your-path.adoc[]
 * xref:debugging:virtualusb-cli-commands.adoc[]

--- a/docs/modules/debugging/pages/index.adoc
+++ b/docs/modules/debugging/pages/index.adoc
@@ -1,4 +1,4 @@
-= Debugging
+= virtualUSB
 :navtitle: Debugging
 
 Debug from anywhere with virtualUSB.


### PR DESCRIPTION
All internal linking is intact and working

### Summary
Top level name changed from Debugging to virtualUSD. All internal linking is intact and working. page-alias were not used. I found a simpler method. Changed the name of the page without changing the nav title. Keeping all internal linking and bookmarks intact.

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- N/A

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x ] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
