### PR TITLE
Update launch-a-basic-appium-2-session.adoc

### DIFF
--- a/docs/modules/automation-testing/pages/basic-appium-server/launch-a-basic-appium-2-session.adoc
+++ b/docs/modules/automation-testing/pages/basic-appium-server/launch-a-basic-appium-2-session.adoc
@@ -90,6 +90,7 @@ Once these changes are made, your script is ready to run basic Appium 2 sessions
 * Session video is available.
 * Mixed sessions are available, but manual interactions in those sessions are not supported.
 * AI features - including Scriptless, generate Appium script, validations, and flexCorrect - are not supported for basic Appium 2 sessions as they rely heavily on exhaust.
+* Devices with passcodes are not currently supported with basic Appium 2.
 
 == Additional notes
 


### PR DESCRIPTION
### Summary
Kris J determined that devices with passcodes are not supported with basic Appium 2. The problem is that when a Basic Appium session is started, deviceConnect stops our running agent and starts the Appium WebDriverAgent, and that WebDriverAgent process often asks that the XCTest passcode to be re-entered, which we can't do automatically. Looking into a fix but adding this for now.

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
