### PR TITLE
Add missing alt text to pages

### DIFF
--- a/docs/modules/automation-testing/pages/capabilities/auto-generate-capabilities.adoc
+++ b/docs/modules/automation-testing/pages/capabilities/auto-generate-capabilities.adoc
@@ -7,17 +7,17 @@ Learn how to auto-generate capabilities and add them to your test script so you 
 
 After you xref:devices:search-for-a-device.adoc[find a device], select the *vertical ellipses* to open the device information.
 
-image:automation-testing:open-device-overview-context.png[width=1400, alt=""]
+image:automation-testing:open-device-overview-context.png[width=1400, alt="Icon to open device information"]
 
 Next, select *Automation Settings*.
 
-image:automation-testing:device-overview-closeup.png[width=750, alt=""]
+image:automation-testing:device-overview-closeup.png[width=750, alt="Device automation settings"]
 
 == Choose capabilities
 
 First, choose a language and a framework for your auto-generated capabilities.
 
-image:automation-testing:automation-settings-closeup.png[width=1200, alt=""]
+image:automation-testing:automation-settings-closeup.png[width=1200, alt="List of capabilities"]
 
 Choose the capabilities you want to add. When you do, your `DesiredCapabilities` object will update automatically.
 
@@ -48,7 +48,7 @@ desiredCapabilities.put("platformVersion", "15.5");
 
 When you're finished, select the *Copy to clipboard* icon so you can update your test script.
 
-image:automation-testing:copy-desired-capabilities-closeup.png[width=750, alt=""]
+image:automation-testing:copy-desired-capabilities-closeup.png[width=750, alt="Copy to clipboard icon"]
 
 == Add capabilities
 

--- a/docs/modules/device-lab-management/pages/deviceConnect/restart-deviceconnect-services.adoc
+++ b/docs/modules/device-lab-management/pages/deviceConnect/restart-deviceconnect-services.adoc
@@ -19,13 +19,13 @@ Select the *Device Management* tab.
 
 The *Device Management* page lists all dedicated mobile devices for the org grouped by Mac mini host. Locate the Mac mini host you want to restart and click the corresponding *Restart services* button.
 
-image:device-lab-management:restart-dc-restart-services-button.PNG[]
+image:device-lab-management:restart-dc-restart-services-button.PNG[width=750, alt="Restart services button"]
 
 In the confirmation modal, choose *Restart Services* again to proceed.
 
 Any active sessions on devices hosted by that Mac mini will be terminated. During the service restart, no actions can be performed on the Mac mini or the connected devices (all the buttons are grayed out). A notification is displayed when the restart completes successfully.
 
-image:device-lab-management:restart-dc-services-restart-successful-popup.PNG[]
+image:device-lab-management:restart-dc-services-restart-successful-popup.PNG[width=750, alt="Successful restart message"]
 
 After the service restart completes, the devices should automatically come back online.
 
@@ -34,7 +34,7 @@ When a Mac mini host's services are restarted using the above method, active ses
 
 * In the Manual or Mixed session, the user receives a _Device disconnected_ error message and the session is terminated with a status of _Terminated_.
 +
-image:device-lab-management:restart-dc-devices-disconnect-popup.PNG[]
+image:device-lab-management:restart-dc-devices-disconnect-popup.PNG[width=750, alt="Error message to indicate a terminated status"]
 
 * Automation and revisit sessions are also terminated with a status of _Terminated_.
 

--- a/docs/modules/device-lab-management/pages/deviceConnect/retrieve-deviceconnect-logs.adoc
+++ b/docs/modules/device-lab-management/pages/deviceConnect/retrieve-deviceconnect-logs.adoc
@@ -23,11 +23,11 @@ Look for the host using its internal IP address or hostname.
 
 Click Save Logs (3 days), or click the dropdown icon and select Save Logs (7 days).
 
-image:device-lab-management:dc-logs-save-logs-dropdown-portal.PNG[]
+image:device-lab-management:dc-logs-save-logs-dropdown-portal.PNG[width=750, alt="Button to save logs"]
 
 Wait for the system to gather the logs. When the logs are ready, click the *Download icon*. The logs are downloaded as a .zip archive.
 
-image:device-lab-management:dc-logs-save-logs-button-portal.PNG[]
+image:device-lab-management:dc-logs-save-logs-button-portal.PNG[width=750, alt="Icon to download logs"]
 
 If the host does not appear on the Device Management page or the Save Logs button for that host is grayed out, see the next section to gather logs using deviceConnect application directly on the Mac mini host.
 
@@ -39,8 +39,6 @@ Open Chrome browser. Enter localhost (using the Mac mini itself) or the local IP
 Log into the deviceConnect portal, then click the *Systems* tab.
 
 Under System logs, choose the duration to gather the logs (the default is 2 days), then click *Save logs*.
-
-image:device-lab-management:dc-logs-save-logs-button-gigafox.PNG[]
 
 The logs are downloaded as a .zip archive.
 

--- a/docs/modules/integrations/pages/create-and-manage-webhooks.adoc
+++ b/docs/modules/integrations/pages/create-and-manage-webhooks.adoc
@@ -29,11 +29,11 @@ include::profile:partial$open-settings.adoc[]
 
 Select the **Webhook Settings** tab.
 
-image:integrations:webhooks-settings-context.png[]
+image:integrations:webhooks-settings-context.png[width=750, alt="Webhook settings tab"]
 
 Select **Create Webhook**.
 
-image:integrations:webhooks-create-button.png[]
+image:integrations:webhooks-create-button.png[width=750, alt="Button to create webhook"]
 
 Complete the required information as described below:
 
@@ -46,11 +46,11 @@ Complete the required information as described below:
 |Event|Yes (at least 1 event enabled)|On/off toggle|The type of event to trigger the callback |
 |=======================
 
-image:integrations:webhooks-create-new-webhook-context.png[]
+image:integrations:webhooks-create-new-webhook-context.png[width=750, alt="Page to create new webhook"]
 
 Choose one or more event triggers by enabling the toggle of each event. Then, select *Save*.
 
-image:integrations:webhooks-create-new-webhook-events.png[]
+image:integrations:webhooks-create-new-webhook-events.png[width=750, alt="Toggle to enable event"]
 
 == Execute a webhook
 
@@ -100,21 +100,21 @@ If you no longer want to receive a callback, delete the webhook.
 
 Navigate to *Webhook Settings*, select a webhook, and choose *Delete*.
 
-image:integrations:webhooks-delete-button.png[]
+image:integrations:webhooks-delete-button.png[width=750, alt="Button to delete webhook"]
 
 Confirm the deletion of the webhook by selecting *Delete* again in the modal:
 
-image:integrations:webhooks-delete-popup.png[]
+image:integrations:webhooks-delete-popup.png[width=750, alt="Button to delete webhook"]
 
 == Edit a webhook
 
 Go to *Webhook Settings*, select a webhook and choose *Edit*.
 
-image:integrations:webhooks-edit-button.png[]
+image:integrations:webhooks-edit-button.png[width=750, alt="Button to edit webhook"]
 
 Make changes and select *Save*.
 
-image:integrations:webhooks-edit-context.png[]
+image:integrations:webhooks-edit-context.png[width=750, alt="Button to save webhook"]
 
 == Verify a webhook
 

--- a/docs/modules/manual-testing/pages/device-information/inspector.adoc
+++ b/docs/modules/manual-testing/pages/device-information/inspector.adoc
@@ -9,7 +9,7 @@ image:manual-testing:inspector-context.png[width=, alt="A manual session display
 
 Display the XML hierarchy of the current device screen. Select a specific element from the hierarchy to highlight it on the device.
 
-image:manual-testing:refresh-inventory-closeup.png[width=, alt=""]
+image:manual-testing:refresh-inventory-closeup.png[width=, alt="The XML hierarchy of the current device screen"]
 
 [NOTE]
 *Refresh inventory* resets all filters and searches.
@@ -18,32 +18,32 @@ image:manual-testing:refresh-inventory-closeup.png[width=, alt=""]
 
 Hover over on-screen elements to highlight the elements in the XML hierarchy.
 
-image:manual-testing:inspect-elements-closeup.png[width=, alt=""]
+image:manual-testing:inspect-elements-closeup.png[width=, alt="The icon to inspect elements"]
 
 == Download inventory
 
 Download the current XML hierarchy as an `.xml` file.
 
-image:manual-testing:download-inventory-closeup.png[width=, alt=""]
+image:manual-testing:download-inventory-closeup.png[width=, alt="The icon to download the XML heirarchy"]
 
 == WebView
 
 Filter the XML hierarchy by the selected WebView. The default WebView is `NATIVE_APP`.
 
-image:manual-testing:inspector-dropdown-closeup.png[width=, alt=""]
+image:manual-testing:inspector-dropdown-closeup.png[width=, alt="The WebView filter"]
 
 == Search bar
 
 Filter the XML hierarchy by a specific element.
 
-image:manual-testing:inspector-search-closeup.png[width=, alt=""]
+image:manual-testing:inspector-search-closeup.png[width=, alt="Search an element to filter that specific element"]
 
 == Attributes
 
 Display an element's attributes.
 
-image:manual-testing:hierarchy-closeup.png[width=, alt=""]
+image:manual-testing:hierarchy-closeup.png[width=, alt="The button to display attributes"]
 
 Hover over a specific attribute and to copy it to your clipboard.
 
-image:manual-testing:attributes-closeup.png[width=, alt=""]
+image:manual-testing:attributes-closeup.png[width=, alt="The icon to copy the attribute"]

--- a/docs/modules/manual-testing/pages/device-information/metrics.adoc
+++ b/docs/modules/manual-testing/pages/device-information/metrics.adoc
@@ -9,22 +9,22 @@ image:manual-testing:metrics-context.png[width=, alt="A manual session displayin
 
 The percentage of the device's memory being used during your test session.
 
-image:manual-testing:memory-closeup.png[width=, alt=""]
+image:manual-testing:memory-closeup.png[width=, alt="The device Memory metrics"]
 
 == CPU
 
 The percentage of the device's CPU being used during your test session.
 
-image:manual-testing:cpu-closeup.png[width=, alt=""]
+image:manual-testing:cpu-closeup.png[width=, alt="The device CPU metrics"]
 
 == Network
 
 The number of bytes the device is receiving and sending over the network during your test session.
 
-image:manual-testing:network-closeup.png[width=, alt=""]
+image:manual-testing:network-closeup.png[width=, alt="The device Network metrics"]
 
 == Battery drain
 
 The speed at which the device's battery is draining during your test session.
 
-image:manual-testing:battery-drain-closeup.png[width=, alt=""]
+image:manual-testing:battery-drain-closeup.png[width=, alt="The device Battery Drain metrics"]

--- a/docs/modules/session-explorer/pages/validations/validate-ui-design.adoc
+++ b/docs/modules/session-explorer/pages/validations/validate-ui-design.adoc
@@ -25,32 +25,32 @@ image:compare-ui-design-context.png[width=1000,alt="Select Compare to UI Design"
 
 To use Figma for validating your UI design, select the dropdown and choose a project.
 
-image:session-explorer:figma-project.png[width=1000,alt=""]
+image:session-explorer:figma-project.png[width=1000,alt="Select a project to compare the UI design"]
 
 [#_use_an_image]
 === Use an image
 
 To use an image for validating your UI design, select the *Upload Images* icon and choose an image to upload.
 
-image:session-explorer:upload-screen.png[width=500,alt=""]
+image:session-explorer:upload-screen.png[width=500,alt="The icon to upload images"]
 
 == Change the project resolution
 
 By default, the project resolution is set to *All*. To change the resolution, select the dropdown and choose a different option.
 
-image:session-explorer:all-resolutions.png[width=500, alt=""]
+image:session-explorer:all-resolutions.png[width=500, alt="Select the project resolution"]
 
 == Search for a frame
 
 To search for a specific frame, type its name into the search bar.
 
-image:session-explorer:search-frame.png[width=500, alt=""]
+image:session-explorer:search-frame.png[width=500, alt="Use the search bar to search for a specific frame"]
 
 == Compare UI design
 
 To compare the UI design, choose an image, then select *Go to comparison view*.
 move
-image:session-explorer:frames-list.png[width=500, alt=""]
+image:session-explorer:frames-list.png[width=500, alt="An image using the comparison view"]
 
 To move the frame, use the arrow buttons or enter a pair of *X* and *Y* coordinates.
 


### PR DESCRIPTION
### Summary
Updating pages to add alt text where it is missing

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- https://kobiton.atlassian.net/browse/KOB-46729
- https://kobiton.atlassian.net/browse/KOB-46732
- https://kobiton.atlassian.net/browse/KOB-46732
- https://kobiton.atlassian.net/browse/KOB-46732
- https://kobiton.atlassian.net/browse/KOB-46732
- https://kobiton.atlassian.net/browse/KOB-46732
- https://kobiton.atlassian.net/browse/KOB-46733
- https://kobiton.atlassian.net/browse/KOB-46736
- https://kobiton.atlassian.net/browse/KOB-46741

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [ ] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [ ] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
