### PR TITLE
chore: add dagger cloud token to push metric to Dagger Cloud for troubleshoot, add `--silent` option to hide s3 buc
ket name in github action log

### DIFF
--- a/.github/actions/call/action.yaml
+++ b/.github/actions/call/action.yaml
@@ -41,3 +41,4 @@ runs:
           --aws-secret-access-key=env:AWS_SECRET_ACCESS_KEY \
           --aws-session-token=env:AWS_SESSION_TOKEN \
           --cloudfront-id=${{ inputs.cloudfront-id }} \
+        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,8 @@ jobs:
             --aws-access-key-id=env:AWS_ACCESS_KEY_ID \
             --aws-secret-access-key=env:AWS_SECRET_ACCESS_KEY \
             --aws-session-token=env:AWS_SESSION_TOKEN \
+          dagger-flags: "--silent"
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
           AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
- Add Dagger Cloud token to push metrics for troubleshooting.
- Add option `--silent` to hide progress, environment variables and S3 bucket information when running CD upgrade portal version in GitHub Actions.

Signed-off-by: luanmtruong <luanmtruong@kobiton.com>
