### PR TITLE
fix: release workflow call need input --bucket

### DIFF
--- a/.github/actions/call/action.yaml
+++ b/.github/actions/call/action.yaml
@@ -57,6 +57,6 @@ runs:
           --aws-secret-access-key=env:AWS_SECRET_ACCESS_KEY \
           --aws-session-token=env:AWS_SESSION_TOKEN \
           --cloudfront-id=${{ inputs.cloudfront-id }} \
-          --bucket ${{ inputs.bucket }} \
+          ${{ inputs.bucket && format('--bucket {0} \\', inputs.bucket) }}
         dagger-flags: "--silent"
         cloud-token: ${{ inputs.dagger-token }}

--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -47,3 +47,17 @@ jobs:
           dagger-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           bucket: "docs-test"
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Docs publish"
+        uses: ./.github/actions/call
+        with:
+          site: "docs"
+          cloudfront-id: ${{ secrets.DOCS_CLOUDFRONT_ID }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+          aws-region: ${{ secrets.AWS_PROD_REGION }}
+          dagger-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Fix **release** workflow call need input `--bucket`

Signed-off-by: luanmtruong <luanmtruong@kobiton.com>
