### PR TITLE
redirect some old ios cert and provisioning pages to the correct ones

### DIFF
--- a/docs/modules/device-lab-management/pages/ios-devices/generate-an-ios-signing-certificate-and-provisioning-profile.adoc
+++ b/docs/modules/device-lab-management/pages/ios-devices/generate-an-ios-signing-certificate-and-provisioning-profile.adoc
@@ -1,5 +1,5 @@
 = Generate iOS signing certificate and provisioning profile
-:page-aliases: apps:ios-apps:generate-an-ios-signing-certificate.adoc, apps:ios-apps:generate-an-ios-provisioning-profile.adoc, apps:manage-ios-apps: generate-an-ios-signing-certificate.adoc, apps:manage-ios-apps:generate-an-ios-provisioning-profile.adoc
+:page-aliases: apps:ios-apps:generate-an-ios-signing-certificate.adoc, apps:ios-apps:generate-an-ios-provisioning-profile.adoc, apps:manage-ios-apps:generate-an-ios-signing-certificate.adoc, apps:manage-ios-apps:generate-an-ios-provisioning-profile.adoc
 
 :navtitle: Generate an iOS signing certificate and a provisioning profile
 


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
- redirect some old ios cert and provisioning pages to the correct ones

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- N/A

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
