### PR TITLE
Correct NPC iOS limitation: Apple domains are reachable but not capturable

### DIFF
--- a/docs/modules/devices/partials/network-payload-capture/npc-limitations.adoc
+++ b/docs/modules/devices/partials/network-payload-capture/npc-limitations.adoc
@@ -5,7 +5,7 @@
 
 * Certificate pinning prevents network payload capture. If you want to capture payload for a native application, make sure to disable certificate pinning in your app.
 
-* iOS devices cannot access any Apple domains (including App Store) in an NPC session.
+* On iOS, Apple domains (including the App Store) stay reachable in an NPC session, so apps can still be verified with Apple before installation. However, NPC can't capture payload on Apple domains because Apple enforces certificate pinning on iOS.
 
 * A custom configuration profile is needed to enable the HTTP Proxy on iOS devices. Therefore, NPC does not work if there is another HTTP Proxy configuration profile installed on the device.
 

--- a/docs/modules/devices/partials/network-payload-capture/npc-limitations.adoc
+++ b/docs/modules/devices/partials/network-payload-capture/npc-limitations.adoc
@@ -5,7 +5,7 @@
 
 * Certificate pinning prevents network payload capture. If you want to capture payload for a native application, make sure to disable certificate pinning in your app.
 
-* On iOS, Apple domains (including the App Store) stay reachable in an NPC session, so apps can still be verified with Apple before installation. However, NPC can't capture payload on Apple domains because Apple enforces certificate pinning on iOS.
+* On iOS, Apple domains (including the App Store) stay reachable in an NPC session, so apps can still be verified with Apple before installation. However, NPC can't capture payload on Apple domains because Apple enforces certificate pinning on iOS. Reaching Apple domains in an NPC session requires deviceConnect 4.25.0 or later.
 
 * A custom configuration profile is needed to enable the HTTP Proxy on iOS devices. Therefore, NPC does not work if there is another HTTP Proxy configuration profile installed on the device.
 


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
- Update a bullet in the shared NPC limitations partial. The old copy said iOS devices can't reach Apple domains (including the App Store) in an NPC session — this was fixed in 4.25. Apple domains stay reachable, so apps can still be verified with Apple before installation; payload capture still fails, however because Apple enforces certificate pinning on iOS for its own domains.

### Changes
- Edited: docs/modules/devices/partials/network-payload-capture/npc-limitations.adoc — replaced the iOS / Apple-domains bullet.
- Downstream (no edits needed, inherit via include::):
  - docs/modules/manual-testing/pages/local-devices/capture-network-payload-data.adoc
  - docs/modules/automation-testing/pages/local-devices/capture-network-payload-data.adoc

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- https://kobiton.atlassian.net/browse/KOB-52639

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
