### PR TITLE
update supported iOS versions and add notes about passcode mode support

### DIFF
--- a/docs/modules/release-notes/pages/all-releases/4_26.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26.adoc
@@ -106,6 +106,7 @@ Existing users can link GitHub or Google accounts to their Kobiton accounts. For
 Available for new accounts, existing users, and organization registration workflows.
 
 === Kobiton MCP server OAuth authentication
+
 The Kobiton MCP server now supports OAuth 2.1 authentication using existing Kobiton credentials.
 
 *Highlights*

--- a/docs/modules/supported-platforms/pages/mobile-operating-systems-and-devices.adoc
+++ b/docs/modules/supported-platforms/pages/mobile-operating-systems-and-devices.adoc
@@ -20,9 +20,11 @@ include::partial$/xcode-compat.adoc[]
 
 |Apple
 |iOS & iPadOS
-|link:https://developer.apple.com/documentation/ios-ipados-release-notes/ios-12-release-notes[iOS 12,window=read-later] ^*2*^ through link:https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes[iOS & iPadOS 26,window=read-later]
+|link:https://developer.apple.com/documentation/ios-ipados-release-notes/ios-12-release-notes[iOS 12,window=read-later] ^*2*^ through link:https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26_4-release-notes[iOS & iPadOS 26.4,window=read-later] ^*3*^
 |===
 
 ^*1*^ _Lower versions may still work, but are no longer tested._
 
 ^*2*^ _iOS 12 and 13 support was reintroduced in release 4.19 with some xref:release-notes:all-releases/4_19.adoc#_re_enabled_ios_12_and_13_support[known limitations,window=read-later]._
+
+^*3*^ _Passcode mode is not supported from 26.0 to 26.2_

--- a/docs/modules/supported-platforms/pages/mobile-operating-systems-and-devices.adoc
+++ b/docs/modules/supported-platforms/pages/mobile-operating-systems-and-devices.adoc
@@ -27,4 +27,4 @@ include::partial$/xcode-compat.adoc[]
 
 ^*2*^ _iOS 12 and 13 support was reintroduced in release 4.19 with some xref:release-notes:all-releases/4_19.adoc#_re_enabled_ios_12_and_13_support[known limitations,window=read-later]._
 
-^*3*^ _Passcode mode is not supported from 26.0 to 26.2_
+^*3*^ _Passcode mode is not supported from iOS/iPadOS 26.0 to 26.2_


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
- Add iOS 26.4 support in supported platform
- Add notes in supported platform about passcode mode not supported for 26.0 to 26.2

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- N/A

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [ ] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
