### PR TITLE
Remove GitHub mention

### DIFF
--- a/docs/modules/ai/nav.adoc
+++ b/docs/modules/ai/nav.adoc
@@ -2,7 +2,7 @@
 ** xref:mcp/index.adoc[MCP]
 *** xref:mcp/claude-code.adoc[Claude Code]
 *** xref:mcp/claude-desktop.adoc[Claude Desktop]
-*** xref:mcp/copilot.adoc[GitHub Copilot CLI]
+*** xref:mcp/copilot.adoc[Copilot CLI]
 *** xref:mcp/gemini.adoc[Gemini CLI]
 *** xref:mcp/codex.adoc[Codex CLI]
 *** xref:mcp/ai-plugin-mcp-ref.adoc[Kobiton AI plugin and tools reference]

--- a/docs/modules/ai/pages/mcp/copilot.adoc
+++ b/docs/modules/ai/pages/mcp/copilot.adoc
@@ -1,5 +1,5 @@
 = Kobiton for Copilot CLI
-:navtitle: GitHub Copilot CLI
+:navtitle: Copilot CLI
 
 Kobiton for GitHub Copilot CLI connects Copilot to the Kobiton mobile testing platform. You can manage devices, upload apps, run automation tests, and review results using natural language commands without switching between the terminal, the Kobiton portal, and local test scripts.
 

--- a/docs/modules/ai/pages/mcp/copilot.adoc
+++ b/docs/modules/ai/pages/mcp/copilot.adoc
@@ -1,4 +1,4 @@
-= Kobiton for GitHub Copilot CLI
+= Kobiton for Copilot CLI
 :navtitle: GitHub Copilot CLI
 
 Kobiton for GitHub Copilot CLI connects the Copilot CLI to the Kobiton mobile testing platform. You can manage devices, upload apps, run automation tests, and review results using natural language commands without switching between the terminal, the Kobiton portal, and local test scripts.

--- a/docs/modules/ai/pages/mcp/copilot.adoc
+++ b/docs/modules/ai/pages/mcp/copilot.adoc
@@ -1,7 +1,7 @@
 = Kobiton for Copilot CLI
 :navtitle: GitHub Copilot CLI
 
-Kobiton for GitHub Copilot CLI connects the Copilot CLI to the Kobiton mobile testing platform. You can manage devices, upload apps, run automation tests, and review results using natural language commands without switching between the terminal, the Kobiton portal, and local test scripts.
+Kobiton for GitHub Copilot CLI connects Copilot to the Kobiton mobile testing platform. You can manage devices, upload apps, run automation tests, and review results using natural language commands without switching between the terminal, the Kobiton portal, and local test scripts.
 
 https://discord.gg/uHvBFDZVP[image:discord-badge.svg[Join our Discord]]
 https://kobiton.com[image:kobiton-cloud.svg[Kobiton Cloud]]

--- a/docs/modules/ai/pages/mcp/index.adoc
+++ b/docs/modules/ai/pages/mcp/index.adoc
@@ -1,7 +1,7 @@
 = MCP
 :navtitle: MCP
 
-Kobiton uses Model Context Protocol (MCP) to connect AI coding assistants - Claude Code, Claude Desktop, the GitHub Copilot CLI, the Gemini CLI, and the Codex CLI - to the Kobiton platform. This integration lets you manage devices, upload apps, run tests, and review results without switching between tools or navigating the Kobiton Portal.
+Kobiton uses Model Context Protocol (MCP) to connect AI coding assistants - Claude Code, Claude Desktop, the Copilot CLI, the Gemini CLI, and the Codex CLI - to the Kobiton platform. This integration lets you manage devices, upload apps, run tests, and review results without switching between tools or navigating the Kobiton Portal.
 
 Common tasks include:
 
@@ -16,7 +16,7 @@ Common tasks include:
 To use Kobiton with MCP, you need:
 
 - A Kobiton account
-- A supported AI assistant installed locally - Claude Code, Claude Desktop, the GitHub Copilot CLI, the Gemini CLI, or the Codex CLI
+- A supported AI assistant installed locally - Claude Code, Claude Desktop, the Copilot CLI, the Gemini CLI, or the Codex CLI
 - Access to the Kobiton plugin or connector
 
 == Setup guides

--- a/docs/modules/ai/pages/mcp/index.adoc
+++ b/docs/modules/ai/pages/mcp/index.adoc
@@ -23,7 +23,7 @@ To use Kobiton with MCP, you need:
 
 - xref:mcp/claude-code.adoc[Kobiton for Claude Code]
 - xref:mcp/claude-desktop.adoc[Kobiton for Claude Desktop]
-- xref:mcp/copilot.adoc[Kobiton for GitHub Copilot CLI]
+- xref:mcp/copilot.adoc[Kobiton for Copilot CLI]
 - xref:mcp/gemini.adoc[Kobiton for Gemini CLI]
 - xref:mcp/codex.adoc[Kobiton for Codex CLI]
 

--- a/docs/modules/release-notes/pages/all-releases/4_26_1S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_1S.adoc
@@ -273,6 +273,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Improved automatic permission handling on iOS and Android devices.
 * Fixed issues with file push and retrieval behavior on devices.
 * Added support for recursive file pull.
+* Improved deviceConnect session cleanup when the CLI connects directly. Sessions now send close messages on completion so they are released cleanly.
 
 == General improvements and fixes
 
@@ -297,6 +298,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Fixed iOS app installation failures caused by ZipConduit errors.
 * Improved performance for app installation on iOS devices.
 * Fixed an issue where iOS app installation could fail under certain proxy configurations.
+* Improved installation reliability for very large applications, including apps with uncompressed sizes over 4 GB.
 
 === Device cleanup
 
@@ -310,6 +312,8 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Improved device connectivity stability to help prevent unexpected disconnects.
 * Improved session stability when USB hubs are disconnected during active sessions.
 * Fixed an issue where offline Bluetooth modules could incorrectly display a "Healthy" status.
+* Fixed an issue where previously unpaired iOS devices did not come online after pairing completed.
+* Fixed an issue where macOS could block `adb` after deviceConnect installation, preventing Android device discovery.
 
 === Device management
 
@@ -336,6 +340,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Fixed an issue where downloaded device logs from a manual session had no line endings, making the file difficult to read.
 * Fixed an issue where Jira tickets created from Session Explorer were not linked back to the session. The Jira button badge and linked ticket list now update correctly after ticket creation.
 * Fixed an issue where the Jira Cloud integration intermittently appeared disconnected after approximately 15 minutes, preventing Jira ticket creation from Session Explorer.
+* Fixed an issue where releasing a device from the Portal did not terminate all active sessions when multi-session was in use.
 
 === Test management
 


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
Remove gratuitous mentions of "GitHub" from title and nav, left one explicit mention in introduction paragraph on Copilot page.

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- N/A

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [ ] Adds new file(s)
- [ ✅ ] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [ ✅ ] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
