### PR TITLE
Release notes 4 26 4 s

### DIFF
--- a/docs/modules/release-notes/nav.adoc
+++ b/docs/modules/release-notes/nav.adoc
@@ -6,7 +6,7 @@
 
 * All releases
 
-** xref:all-releases/4_26_1S.adoc[]
+** xref:all-releases/4_26_4S.adoc[]
 ** xref:all-releases/4_26.adoc[]
 ** xref:all-releases/4_25.adoc[]
 ** xref:all-releases/4_24.adoc[]

--- a/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
@@ -275,7 +275,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Fixed issues with file push and retrieval behavior on devices.
 * Added support for recursive file pull.
 * Improved deviceConnect session cleanup when the CLI connects directly. Sessions now send close messages on completion so they are released cleanly.
-* The CLI `test --stream` command now retrieves a device-signed app through the Portal signed-app API, preserving app entitlements (such as APNs) during streamed test runs.
+* The CLI `test run --stream` command now retrieves a device-signed app through the Portal signed-app API, preserving app entitlements (such as APNs) during streamed test runs.
 
 == General improvements and fixes
 
@@ -297,8 +297,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 === App installation
 
 * Fixed an issue where concurrent app installations could fail.
-* Fixed iOS app installation failures caused by ZipConduit errors.
-* Improved performance for app installation on iOS devices.
+* Improved performance for app installation on iOS devices via `afc` file transfer method.
 * Fixed an issue where iOS app installation could fail under certain proxy configurations.
 * Improved installation reliability for very large applications, including apps with uncompressed sizes over 4 GB.
 
@@ -316,7 +315,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Fixed an issue where offline Bluetooth modules could incorrectly display a "Healthy" status.
 * Fixed an issue where previously unpaired iOS devices did not come online after pairing completed.
 * Fixed an issue where macOS could block `adb` after deviceConnect installation, preventing Android device discovery.
-* Fixed an issue where a macOS "find devices on local networks" prompt could reappear periodically while deviceConnect maintained the adb server.
+* Fixed an issue where `find devices on local networks` prompt appears that blocks `adb` in the Mac mini host.
 
 === Device management
 

--- a/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
@@ -1,7 +1,7 @@
-= Kobiton 4.26.1S Release Notes
-:navtitle: Kobiton 4.26.1S release notes
+= Kobiton 4.26.4S Release Notes
+:navtitle: Kobiton 4.26.4S release notes
 
-_May 15, 2026_
+_June 1, 2026_
 
 == deviceConnect service management migration to launchd
 
@@ -261,6 +261,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 ** Standardized `SetLocale` behavior across iOS and Android
 ** iPad orientation now persists after language changes
 * *Basic Appium:* Fixed app installation failures when using app URLs.
+* *Native testing:* Fixed an issue where xcodebuild-based native iOS tests could intermittently fail to locate the target device.
 * *UI updates:*
 ** Additional apps installed after automation session start are now displayed in Session Overview
 ** Improved error message when no devices matched a wildcard
@@ -274,6 +275,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Fixed issues with file push and retrieval behavior on devices.
 * Added support for recursive file pull.
 * Improved deviceConnect session cleanup when the CLI connects directly. Sessions now send close messages on completion so they are released cleanly.
+* The CLI `test --stream` command now retrieves a device-signed app through the Portal signed-app API, preserving app entitlements (such as APNs) during streamed test runs.
 
 == General improvements and fixes
 
@@ -314,6 +316,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 * Fixed an issue where offline Bluetooth modules could incorrectly display a "Healthy" status.
 * Fixed an issue where previously unpaired iOS devices did not come online after pairing completed.
 * Fixed an issue where macOS could block `adb` after deviceConnect installation, preventing Android device discovery.
+* Fixed an issue where a macOS "find devices on local networks" prompt could reappear periodically while deviceConnect maintained the adb server.
 
 === Device management
 
@@ -330,6 +333,7 @@ Instructions to connect to Standalone MCP server is coming soon.
 
 * Added support for Xcode 26 DDI changes to prevent DDI failures on newer iOS devices.
 * Fixed an issue where iOS 18.5 and 18.6 devices with passcode enabled lost connection after switching language.
+* Improved iOS CoreDevice connection stability, resolving several cases where devices could remain offline after a lockdown error or a transient connection timeout under heavy host load.
 
 === Session and integration
 

--- a/docs/modules/release-notes/pages/standalone-kobiton-four-latest.adoc
+++ b/docs/modules/release-notes/pages/standalone-kobiton-four-latest.adoc
@@ -1,4 +1,4 @@
 = Kobiton 4+ Standalone latest updates
 :navtitle: Kobiton 4+ Standalone latest updates
 
-include::all-releases/4_26_1S.adoc[leveloffset=1]
+include::all-releases/4_26_4S.adoc[leveloffset=1]


### PR DESCRIPTION
### Summary
<!-- In one or two sentences, describe your changes. -->
Summary

Promotes the Standalone release-notes page from 4.26.1S to a cumulative 4.26.4S note, folding in the user-facing changes from fix versions 4.26.2, 4.26.3, and 4.26.4. These are deviceConnect, CLI, and iOS app-installation fixes — no Portal-only items appeared in the version reports.

Changes

Page rename + retitle

- rename 4_26_1S.adoc → 4_26_4S.adoc
- Heading: "Kobiton 4.26.1S Release Notes" → "Kobiton 4.26.4S Release Notes"
- Date: May 15, 2026 → June 1, 2026
- Repointed both references: nav.adoc and standalone-kobiton-four-latest.adoc

New release-note items added

- Device connectivity — Fixed the find devices on local networks prompt that blocked adb on the Mac mini host. (KOB-53039)
- iOS and deviceConnect — Improved iOS CoreDevice connection stability; devices no longer stuck offline after a lockdown error or transient timeout under heavy host load. (KOB-53034, KOB-53068, KOB-53272)
- Automation — xcodebuild-based native iOS tests no longer intermittently fail to locate the target device. (KOB-52773)
- Kobiton CLI — test run --stream now retrieves a device-signed app via the Portal signed-app API, preserving entitlements such as APNs. (KOB-52800)

App installation section refined

- Clarified the iOS install-performance improvement as being via the afc file transfer method

Intentionally not duplicated — already documented on the existing page: KOB-53036 (unpaired device pairing), KOB-53035 (CLI direct-connect session cleanup), KOB-53014 (multi-session Portal release), KOB-53037 (>4 GB app install).

### Related PRs, issues, or features (optional)
<!-- Add "Fixes #XYZ" (Replace #XYZ with the GitHub issue or feature number). -->
- https://kobiton.atlassian.net/browse/KOB-53323

### Metadata
<!-- ✅ Check all boxes that apply, like this: [x] -->
- [] Adds new file(s)
- [x] Edits existing file(s)
- [ ] Removes file(s)

### PR contributor checklist
<!-- Once you've filled out your metadata, select "Create Draft Pull Request" and review your PR _before_ filling out the following checklist. -->

- [x] My PR follows the [Kobiton Docs contributor guidelines](https://github.com/kobiton/docs/blob/main/CONTRIBUTE.adoc), meaning:

    - My content contains correct spelling and grammar.
    - My directories and files are [named](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-and-file-names) and [structured](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#directory-structure) correctly.
    - My style and voice follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/brand-voice-above-all-simple-human).
    - I added all new pages to their section's [`nav.adoc` file](https://github.com/kobiton/docs/blob/main/CONTRIBUTING.md#configure-navigation-in-navadoc).
    - I removed all localizations (like `en-us`) from my URLs.
