### PR TITLE
docs(release-notes): add Kobiton 4.26.4S standalone release notes

### DIFF
--- a/docs/modules/release-notes/nav.adoc
+++ b/docs/modules/release-notes/nav.adoc
@@ -6,6 +6,7 @@
 
 * All releases
 
+** xref:all-releases/4_26_4S.adoc[]
 ** xref:all-releases/4_26S.adoc[]
 ** xref:all-releases/4_26.adoc[]
 ** xref:all-releases/4_25.adoc[]

--- a/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
@@ -1,8 +1,7 @@
 = Kobiton 4.26.4S Release Notes
 :navtitle: Kobiton 4.26.4S release notes
 
-// TODO: Confirm the release date before publishing. Deployments spanned May 20–June 10, 2026.
-_Release date to be confirmed_
+_Monday, June 15_
 
 == New features and major changes
 
@@ -23,26 +22,31 @@ Device-only view is useful for demos, screen sharing, and observing automation r
 
 Available for in-progress live sessions.
 
-=== Guide AI-driven sessions from the device canvas
+=== Guide AI-driven sessions from device-only view
 
-During an AI-driven session in device-only view, tap or swipe on the device canvas to steer the device. The agent observes your touch and swipe input between its scripted commands and acknowledges it.
+During an AI-driven session in device-only view, tap or swipe on the device screen to steer the device. The agent observes your touch and swipe input between its scripted commands and acknowledges it.
 
 *Highlights*
 
-- Tap or swipe on the device canvas in device-only view to signal intent to the AI agent.
-- A new `getUserInputEvents` MCP tool lets the agent read these canvas events.
-- Only canvas touch and swipe are sent to the device. Keyboard input and other interactions remain disabled in device-only view.
+- Tap or swipe on the device screen in device-only view to signal intent to the AI agent.
+- A new `getUserInputEvents` MCP tool lets the agent read these events.
+- Only screen touch and swipe are sent to the device. Keyboard input and other interactions remain disabled in device-only view.
 
 *Availability*
 
 Requires device-only view.
+
+== Python support for Appium Script Generation
+
+Appium script generation now supports Python with the `pytest` framework. To generate a Python script, convert a completed Manual Session to a test case from Session Explorer. Then open the test case, select Generate Script, and choose Python from the language dropdown.
+
+NOTE: This feature requires IQS. Contact your Account Manager for more information.
 
 == Bug fixes and improvements
 
 === Appium and automation
 
 - Fixed an issue where recorded text-entry steps were omitted from generated Python (pytest) scripts, causing form submissions to run against empty fields.
-- Fixed an issue where generated Python (pytest) scripts could fail at the first screen transition after a form submission.
 
 === ADB shell
 
@@ -54,12 +58,8 @@ Requires device-only view.
 
 === Device management
 
-- Added the OS build number to the device details modal for Android and iOS devices.
+- Added the OS build number to the device details modal for Android and iOS devices. OS build numbers can be used to differentiate between beta versions of the same operating system release.
 - Added an OS build number filter to *Device List* search.
-
-=== Manual sessions
-
-- Fixed an issue where command latency was missing or calculated incorrectly for sessions that reconnected multiple times.
 
 === MCP server
 
@@ -78,11 +78,13 @@ Requires device-only view.
 [NOTE]
 ====
 
-These release notes pertain to:
+Starting with this release, the overall Standalone release number matches the Portal version number. Other platform components may be versioned independently.
 
-* portal 4.26.4S
+This release corresponds to the following component versions:
+
+* Portal 4.26.4S
 * deviceConnect 4.26.5
 * deviceShare 4.26.0
-* gigacap 4.26.5 with ADB (android debug bridge) 36.0.2
+* Gigacap 4.26.5 with ADB (android debug bridge) 36.0.2
 
 ====

--- a/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
@@ -14,10 +14,10 @@ Device-only view is useful for demos, screen sharing, and observing automation r
 
 *Highlights*
 
-- Activate device-only view by adding `?view=device-only` to a live session URL.
-- The device canvas is display-only. Touches, swipes, and keyboard input are not sent to the device under test.
+- Activate device-only view by adding `&view=device-only` to a live session URL.
+- In device-only view, only touches and swipes are sent to the device. Keyboard input is not sent to the device under test.
 - A floating exit button ends the session and releases the device. When an Appium session is running, the button instead closes the live view and keeps the automation running.
-- For AI-assisted workflows, the `getSession` and `getSessionArtifacts` MCP tools now return `liveViewUrl` and `deviceOnlyViewUrl`.
+- For AI-assisted workflows, you can retrieve the live view and the device-only view from the agent during a live session.
 
 *Availability*
 
@@ -25,15 +25,13 @@ Available for in-progress live sessions.
 
 === Guide AI-driven sessions from the device canvas
 
-During an AI-driven session in device-only view, tap or swipe on the device canvas to guide the agent. The agent observes your touch and swipe input between its scripted commands and reacts to it, such as shifting focus to a screen you just opened.
-
-Canvas input is observational only. It is not sent to the device under test, and the agent continues to drive the device through its own commands.
+During an AI-driven session in device-only view, tap or swipe on the device canvas to steer the device. The agent observes your touch and swipe input between its scripted commands and acknowledges it.
 
 *Highlights*
 
 - Tap or swipe on the device canvas in device-only view to signal intent to the AI agent.
 - A new `getUserInputEvents` MCP tool lets the agent read these canvas events.
-- Only canvas touch and swipe are captured. Keyboard input and other interactions remain disabled in device-only view.
+- Only canvas touch and swipe are sent to the device. Keyboard input and other interactions remain disabled in device-only view.
 
 *Availability*
 

--- a/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
@@ -1,0 +1,78 @@
+= Kobiton 4.26.4S Release Notes
+:navtitle: Kobiton 4.26.4S release notes
+
+// TODO: Confirm the release date before publishing. Deployments spanned May 20–June 10, 2026.
+_Release date to be confirmed_
+
+== New features and major changes
+
+=== Device-only view for live sessions
+
+View just the device screen during a live session, without the surrounding Kobiton interface. Device-only view hides the sidebars, headers, and panels and sizes the viewport to the device screen. It works for phones and tablets, on Android and iOS, in portrait and landscape.
+
+Device-only view is useful for demos, screen sharing, and observing automation runs.
+
+*Highlights*
+
+- Activate device-only view by adding `?view=device-only` to a live session URL.
+- The device canvas is display-only. Touches, swipes, and keyboard input are not sent to the device under test.
+- A floating exit button ends the session and releases the device. When an Appium session is running, the button instead closes the live view and keeps the automation running.
+- For AI-assisted workflows, the `getSession` and `getSessionArtifacts` MCP tools now return `liveViewUrl` and `deviceOnlyViewUrl`.
+
+*Availability*
+
+Available for in-progress live sessions.
+
+=== Guide AI-driven sessions from the device canvas
+
+During an AI-driven session in device-only view, tap or swipe on the device canvas to guide the agent. The agent observes your touch and swipe input between its scripted commands and reacts to it, such as shifting focus to a screen you just opened.
+
+Canvas input is observational only. It is not sent to the device under test, and the agent continues to drive the device through its own commands.
+
+*Highlights*
+
+- Tap or swipe on the device canvas in device-only view to signal intent to the AI agent.
+- A new `getUserInputEvents` MCP tool lets the agent read these canvas events.
+- Only canvas touch and swipe are captured. Keyboard input and other interactions remain disabled in device-only view.
+
+*Availability*
+
+Requires device-only view.
+
+== Bug fixes and improvements
+
+=== Appium and automation
+
+- Fixed an issue where recorded text-entry steps were omitted from generated Python (pytest) scripts, causing form submissions to run against empty fields.
+- Fixed an issue where generated Python (pytest) scripts could fail at the first screen transition after a form submission.
+
+=== ADB shell
+
+- Fixed an issue where the `am start` command was rejected as an unsupported command when launching protected system apps such as Chrome and Settings.
+
+=== App management
+
+- Fixed an issue where installing an app version whose file had been removed from storage returned an unclear error. Affected versions now return a clear, actionable message.
+
+=== Device management
+
+- Added the OS build number to the device details modal for Android and iOS devices.
+- Added an OS build number filter to *Device List* search.
+
+=== Manual sessions
+
+- Fixed an issue where command latency was missing or calculated incorrectly for sessions that reconnected multiple times.
+
+=== MCP server
+
+- Added a `getAppParsingStatus` tool so AI agents can confirm an uploaded app has finished processing before they use it.
+- Fixed the `listSessions` tool ignoring the `limit` and `offset` parameters. Agents can now control how many sessions are returned.
+- Removed misleading app expiry fields (`expiry_date` and `is_expired`) from `listApps` and `getApp` responses. Uploaded apps remain usable and do not expire.
+
+=== API and CLI
+
+- Improved the error message returned when app signing cannot proceed, replacing a generic server error with a descriptive message.
+
+=== SSO sign-in
+
+- Added a clear error message on the SSO sign-in page when an organization's SSO name is invalid.

--- a/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
+++ b/docs/modules/release-notes/pages/all-releases/4_26_4S.adoc
@@ -74,3 +74,15 @@ Requires device-only view.
 === SSO sign-in
 
 - Added a clear error message on the SSO sign-in page when an organization's SSO name is invalid.
+
+[NOTE]
+====
+
+These release notes pertain to:
+
+* portal 4.26.4S
+* deviceConnect 4.26.5
+* deviceShare 4.26.0
+* gigacap 4.26.5 with ADB (android debug bridge) 36.0.2
+
+====

--- a/docs/modules/release-notes/pages/standalone-kobiton-four-latest.adoc
+++ b/docs/modules/release-notes/pages/standalone-kobiton-four-latest.adoc
@@ -1,4 +1,4 @@
 = Kobiton 4+ Standalone latest updates
 :navtitle: Kobiton 4+ Standalone latest updates
 
-include::all-releases/4_26S.adoc[leveloffset=1]
+include::all-releases/4_26_4S.adoc[leveloffset=1]


### PR DESCRIPTION
## Summary

Adds the **Kobiton 4.26.4S** standalone release-notes page and wires it into the release-notes nav. Generated through the **Robot Ranch** (docs-workflow) `release-note` pipeline from the deployment log in `.ai/project-specific/portal-deployments-may20-jun10.md` (May 20 – June 10, 2026) plus normalized Jira evidence.

- New page: `docs/modules/release-notes/pages/all-releases/4_26_4S.adoc`
- Nav: added the entry above `4_26S.adoc` in `nav.adoc`

## Related issues

- https://kobiton.atlassian.net/browse/KOB-53664

## Pipeline (which ranch hands ran)

| Step | Ranch hand | Outcome |
|------|-----------|---------|
| Classify | Valentine (jira-bucketer) | Triaged 20 deployment rows; separated release-note candidates from internal/ops |
| Update vs new | Scout (git-scout) | Newest cloud page `4_26.adoc` is dated May 9; these land after it → new page |
| Affected mentions | Bloodhound | **Skipped** — additive notes, no existing prose to drift |
| Clean source | Scrubber | **Skipped** — clean Markdown table + structured Jira, nothing to scrub |
| Fetch evidence | Dish (jira-draft) | Fetched + normalized 16 Jira tickets (all **Released**) |
| Draft | Ledger (docs-writer) | `release-note` mode draft |
| Style | Style Sheriff | Pass, 0 required fixes |
| Gate | Gatekeeper | Ready (1 intentional placeholder: release date) |

## Ticket → entry mapping (IDs omitted from public copy per release-note rules)

**Features**
- `KOB-52769` — Device-only view for live sessions
- `KOB-53093` — Guide AI-driven sessions from the device canvas (`getUserInputEvents`)

**Bug fixes and improvements**
- `KOB-53091`, `KOB-53267` — Appium/Python generated-script fixes
- `KOB-51850` — ADB shell `am start` for protected packages
- `KOB-52914` — clearer error for app versions with removed storage files
- `KOB-53274`, `KOB-53275` — OS build number in device modal + Device List search
- `KOB-53279` — manual-session command latency with multiple reconnects
- `KOB-53331`, `KOB-53325`, `KOB-53324` — MCP server tools
- `KOB-53218` — app-signing API error message
- `KOB-53326` — SSO sign-in invalid company name message

**Excluded as internal / not user-visible:** `KOB-53351` (v1→v2 MCP endpoint migration), `KOB-52724` (`ai_tool_name` telemetry), `KOB-53009` (PostHog), `KOB-52949` (CI workflow), `KOB-52999` / `KOB-52412` (image-tag bumps).

## Reviewer action items
- [ ] Confirm and fill the **release date** (placeholder in the page; deployments spanned May 20 – June 10, 2026).
- [ ] Confirm whether `4.26.4S` is the latest standalone page. `4_26S.adoc` carries a `:page-aliases:` to `4_26_5S`, so `standalone-kobiton-four-latest.adoc` was **not** repointed — adjust if 4.26.4S should be the standalone "latest".
- [ ] `KOB-52412` appears in the deployment log labeled "update image tags," but is referenced elsewhere as the Python pytest parent story — verify the intended classification.
- [ ] `KOB-51850`: the fix addresses the `am start` "Unsupported command" rejection for protected packages. Launching Work Profile apps across users remains an Android security limitation and is intentionally not claimed as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)