### PR TITLE
docs(KOB-53675): release-note draft

### DIFF
--- a/docs/modules/release-notes/pages/all-releases/KOB-53675-draft.adoc
+++ b/docs/modules/release-notes/pages/all-releases/KOB-53675-draft.adoc
@@ -1,0 +1,44 @@
+= Release note draft: KOB-53675
+:navtitle: KOB-53675 release note draft
+
+[NOTE]
+====
+This is an unreviewed automated draft produced by the docs-writer (Ledger) ranch hand in a CI context. It is *not* a published release note. It is not wired into `nav.adoc` and must not be merged as-is. Drafting was blocked because no source evidence was available — see *Open questions or verification needed* below.
+====
+
+== Mode
+
+`release-note`
+
+== Source evidence used
+
+None. No source evidence was available to draft from:
+
+* No `features/KOB-53675*` spec folder exists on the `.ai` `main` branch.
+* No Jira or Atlassian access is available in this CI session, so the Dish (`jira-draft`) ranch hand could not fetch or normalize the ticket.
+* No PR summary, deployment PR, or release context was supplied.
+* No reference to `KOB-53675` exists in the workspace or the docs repository.
+
+== Draft output
+
+No draft was produced. Per the docs-writer core rules, Ledger does not proceed without source evidence and does not invent product details, UI labels, release versions, or user-facing behavior. Producing release-note prose here would require fabricating the change being described.
+
+To unblock drafting, supply one of the following as approved source evidence:
+
+* The normalized Jira ticket for KOB-53675 (summary, description, acceptance criteria), via the Dish (`jira-draft`) ranch hand or directly.
+* A PR summary or code-diff summary describing the user-visible change.
+* A populated `features/KOB-53675*` spec folder on the `.ai` branch.
+
+Once evidence is available, the release note belongs in the public docs `release-notes` module, under `all-releases/`, as a new per-release entry keyed to the release version that ships this change.
+
+== Open questions or verification needed
+
+* What user-visible change does KOB-53675 introduce? No evidence describes the feature, fix, or behavior change.
+* Which release version (and date) does this change ship in? The correct `all-releases/` page name depends on the version and cannot be assigned without it.
+* Is this a new feature/enhancement or a bug fix? This determines the release-note shape (titled entry with highlights vs. a grouped bug-fix item).
+* What is the affected product surface and the exact UI labels, settings, or API names involved? These must not be invented.
+* Are there availability conditions (subscription, deployment type, enablement, permissions) that should be noted?
+
+== User-facing impact summary
+
+Undetermined. The practical user value or visible effect cannot be stated without source evidence describing the change.


### PR DESCRIPTION
## Source

- Ticket: KOB-53675
- .ai branch / ref used: `main`
- Spec folder: `(none found)` (in kobiton/.ai)
- Deployment PR: (none provided)

## How this was generated

Auto-drafted by the docs-writer skill via the trigger-docs-writer.yaml
workflow in kobiton/.ai.

## Review checklist for the docs team

- [ ] Verify factual accuracy against the source ticket
- [ ] Check style / voice per references/style-guide.md
- [ ] Resolve any "open questions" flagged by the skill in the workflow log
