### PR TITLE
docs(KOB-53654): mask LLM API key in Session Explorer for Appium AI sessions

### DIFF
--- a/docs/modules/automation-testing/pages/appium-ai/override-llm.adoc
+++ b/docs/modules/automation-testing/pages/appium-ai/override-llm.adoc
@@ -116,3 +116,4 @@ Local endpoints are resolved from the host running the Appium session. For examp
 - Capabilities apply only to the session that passed them; other sessions continue to use the defaults.
 - `kobiton:llmApiFormat` must match the provider used by `kobiton:llmBaseUrl`.
 - Vision-based features require a model that accepts image input such as screenshots.
+- Kobiton masks `kobiton:llmApiKey` in session artifacts. In Session Explorer, the value appears as `+******+` in the WebDriver Traffic request and response bodies, and Kobiton redacts it in the session's Appium log. Masking covers existing sessions and does not change the key sent to your LLM provider.


### PR DESCRIPTION
## Source

- Ticket: KOB-53654
- .ai branch / ref used: `KOB-53654`
- Spec folder: `features/KOB-53654-llm-api-key-exposed-webdriver-traffic` (in kobiton/.ai)
- Deployment PR: (none provided)

## How this was generated

Auto-drafted by the docs-writer skill via the trigger-docs-writer.yaml
workflow in kobiton/.ai.

## Review checklist for the docs team

- [ ] Verify factual accuracy against the source ticket
- [ ] Check style / voice per references/style-guide.md
- [ ] Resolve any "open questions" flagged by the skill in the workflow log
